### PR TITLE
Update 2020-06-24.md

### DIFF
--- a/meetings/2020-06-24.md
+++ b/meetings/2020-06-24.md
@@ -1,60 +1,6 @@
 # ASWF USDWG Meeting - June 24, 2020
 
-[Live Agenda](https://docs.google.com/document/d/1FMR4-u5Ri07W2ICJBhH_AP_W6YXgwCpMJsSqPK9lAQw/edit?usp=sharing)
-
-## Attendance
-
-* [x] Cory Omand - WG Chair, Pixar/TWDS
-* [ ] Alan Blevins, Dreamworks
-* [ ] Alex Schwank, Apple
-* [ ] Aloys Baillet, Animal Logic
-* [ ] Andy Biar,  Warner Bros.
-* [ ] Brian Green, Dreamworks
-* [ ] Carson Brownlee, Intel
-* [ ] Charles Fleche, Rodeo FX
-* [ ] Chris Rydalch, Blue Sky Studios
-* [ ] Daniel Heckenberg, Animal Logic
-* [ ] Dhruv Govil, Apple
-* [ ] Eoin Murphy, Animal Logic
-* [ ] Eric Enderton, NVidia
-* [ ] Francois Lord, Rodeo FX
-* [ ] Gary Jones, Foundry
-* [ ] Gordon Bradley, Autodesk
-* [ ] Henry Vera, DNEG
-* [ ] James Pedlingham, Foundry
-* [ ] Jeff Bradley, Dreamworks
-* [ ] John Hood, SPI
-* [ ] John Mertic, Linux Foundation
-* [ ] Jordan Soles, Rodeo FX
-* [ ] JT Nelson, Pasadena Open Source Consortium/SoCal Blender group
-* [ ] Kimball Thurston, Weta
-* [ ] Larry Gritz, SPI
-* [ ] Lee Kerley, SPI
-* [ ] Mark Elendt, SideFX
-* [ ] Mark Final, Foundry
-* [ ] Mark Tucker, SideFX
-* [ ] Matthew Levine, WDAS
-* [ ] Michael B. Johnson, Apple
-* [ ] Michael Kass, NVidia
-* [ ] Michael Min, Netflix
-* [ ] Niall Redmond, Foundry
-* [ ] Nick Porcino, Pixar
-* [ ] Pilar Molina Lopez, Blue Sky Studios
-* [ ] Pier Paolo Ciarravano, MPC
-* [ ] Robin Rowe, CinePaint
-* [ ] Roman Zulak, SPI
-* [ ] Rory Woodford, Foundry
-* [ ] Sean Looper, AWS
-* [ ] Sean McDuffee, Intel
-* [ ] Serguei Kalentchouk, Apple
-* [ ] Shawn Dunn, Epic Games
-* [ ] Toby Jones, Walt Disney Animation Studios
-* [ ] Ben Chung-Hoon, Google
-* [ ] Sue Sauer, Sunrise Productions
-* [ ] Richard Lei, Weta
-* [ ] Bill Spitzak, Dreamworks Animation
-
-## Apologies
+[Minutes](https://docs.google.com/document/d/1FMR4-u5Ri07W2ICJBhH_AP_W6YXgwCpMJsSqPK9lAQw/edit?usp=sharing)
 
 ## Agenda
 


### PR DESCRIPTION
Remove attendance from the github form going forward -- this is managed in the "Live Agenda" (now "Minutes") document to eliminate the need for me to synchronize these manually.

Signed-off-by: Cory Omand <comand@users.noreply.github.com>